### PR TITLE
Use type guard functions in schema module

### DIFF
--- a/src/yup/schemas/schema.ts
+++ b/src/yup/schemas/schema.ts
@@ -26,13 +26,13 @@ import { SchemaItem } from "../types";
  */
 
 export const validateTypeOfValue = {
-  [DataTypes.STRING]: (val: unknown): boolean => isString(val),
-  [DataTypes.NUMBER]: (val: unknown): boolean => isNumber(val),
-  [DataTypes.BOOLEAN]: (val: unknown): boolean => isBoolean(val),
-  [DataTypes.OBJECT]: (val: unknown): boolean => isPlainObject(val),
-  [DataTypes.NULL]: (val: unknown): boolean => isNull(val),
-  [DataTypes.ARRAY]: (val: unknown): boolean => isArray(val),
-  [DataTypes.INTEGER]: (val: unknown): boolean => isInteger(val)
+  [DataTypes.STRING]: isString,
+  [DataTypes.NUMBER]: isNumber,
+  [DataTypes.BOOLEAN]: isBoolean,
+  [DataTypes.OBJECT]: isPlainObject,
+  [DataTypes.NULL]: isNull,
+  [DataTypes.ARRAY]: isArray,
+  [DataTypes.INTEGER]: isInteger
 };
 
 /**


### PR DESCRIPTION
Simplifies "validateTypeOfValue" definition and provides additional type safety

# Before

<img width="623" alt="Screen Shot 2020-03-25 at 12 31 41 pm" src="https://user-images.githubusercontent.com/590992/77492450-b6d74d80-6e94-11ea-82bf-d08d308b191b.png">

# After

<img width="623" alt="Screen Shot 2020-03-25 at 12 31 53 pm" src="https://user-images.githubusercontent.com/590992/77492457-ba6ad480-6e94-11ea-8dc3-7413b4555d85.png">