### PR TITLE
Set label to field title if it exists

### DIFF
--- a/src/yup/schemas/array/array.schema.ts
+++ b/src/yup/schemas/array/array.schema.ts
@@ -27,11 +27,14 @@ const createArraySchema = (
     maxItems,
     items,
     contains,
-    uniqueItems
+    uniqueItems,
+    title
   } = value;
 
+  const label = title || capitalize(key);
+
   const defaultMessage =
-    getError("defaults.array") || capitalize(`${key} is not of type array`);
+    getError("defaults.array") || `${label} is not of type array`;
 
   let Schema = Yup.array().typeError(defaultMessage);
 

--- a/src/yup/schemas/boolean/boolean.schema.ts
+++ b/src/yup/schemas/boolean/boolean.schema.ts
@@ -15,10 +15,12 @@ const createBooleanSchema = (
   [key, value]: SchemaItem,
   jsonSchema: JSONSchema7
 ): Yup.BooleanSchema<boolean> => {
-  const { default: defaults } = value;
+  const { default: defaults, title } = value;
+
+  const label = title || capitalize(key);
 
   const defaultMessage =
-    getError("defaults.boolean") || capitalize(`${key} is not of type boolean`);
+    getError("defaults.boolean") || `${label} is not of type boolean`;
 
   let Schema = Yup.boolean().typeError(defaultMessage);
 

--- a/src/yup/schemas/integer/integer.schema.ts
+++ b/src/yup/schemas/integer/integer.schema.ts
@@ -13,8 +13,12 @@ const createIntegerSchema = (
   [key, value]: SchemaItem,
   jsonSchema: JSONSchema7
 ): Yup.NumberSchema<number> => {
+  const { title } = value;
+
+  const label = title || capitalize(key);
+
   const defaultMessage =
-    getError("defaults.integer") || capitalize(`${key} is not of type integer`);
+    getError("defaults.integer") || `${label} is not of type integer`;
   return createBaseNumberSchema(
     Yup.number().typeError(defaultMessage).integer().strict(true),
     [key, value],

--- a/src/yup/schemas/number/number.schema.ts
+++ b/src/yup/schemas/number/number.schema.ts
@@ -17,8 +17,12 @@ const createNumberSchema = (
   [key, value]: SchemaItem,
   jsonSchema: JSONSchema7
 ): Yup.NumberSchema<number> => {
+  const { title } = value;
+
+  const label = title || capitalize(key);
+
   const defaultMessage =
-    getError("defaults.number") || capitalize(`${key} is not of type number`);
+    getError("defaults.number") || `${label} is not of type number`;
 
   return createBaseNumberSchema(
     Yup.number().typeError(defaultMessage),

--- a/src/yup/schemas/object/object.schema.ts
+++ b/src/yup/schemas/object/object.schema.ts
@@ -13,8 +13,12 @@ const createObjectSchema = (
   [key, value]: SchemaItem,
   jsonSchema: JSONSchema7
 ): Yup.ObjectSchema<object> => {
+  const { title } = value;
+
+  const label = title || capitalize(key);
+
   const defaultMessage =
-    getError("defaults.object") || capitalize(`${key} is not of type object`);
+    getError("defaults.object") || `${label} is not of type object`;
 
   let Schema = Yup.object().typeError(defaultMessage);
 

--- a/src/yup/schemas/required.ts
+++ b/src/yup/schemas/required.ts
@@ -17,8 +17,9 @@ export const createRequiredSchema = <T extends Yup.Schema<any>>(
 ): T => {
   if (!isRequiredField(jsonSchema, key)) return Schema;
 
-  const { description } = value;
+  const { description, title } = value;
+  const label = title || capitalize(key);
   const path = joinPath(description, "required");
-  const message = getError(path) || capitalize(`${key} is required`);
+  const message = getError(path) || `${label} is a required field`;
   return Schema.concat(Schema.required(message));
 };

--- a/src/yup/schemas/required.ts
+++ b/src/yup/schemas/required.ts
@@ -20,6 +20,6 @@ export const createRequiredSchema = <T extends Yup.Schema<any>>(
   const { description, title } = value;
   const label = title || capitalize(key);
   const path = joinPath(description, "required");
-  const message = getError(path) || `${label} is a required field`;
+  const message = getError(path) || `${label} is required`;
   return Schema.concat(Schema.required(message));
 };

--- a/src/yup/schemas/string/string.schema.ts
+++ b/src/yup/schemas/string/string.schema.ts
@@ -103,19 +103,19 @@ export const stringSchemaFormat = (
   if (format === "date-time") {
     const path = joinPath(description, "format.dateTime");
     const message =
-      getError(path) || `${label} is a invalid date and time format`;
+      getError(path) || `${label} is an invalid date and time format`;
     Schema = Schema.concat(Schema.matches(ISO_8601_DATE_TIME_REGEX, message));
   }
 
   if (format === "time") {
     const path = joinPath(description, "format.time");
-    const message = getError(path) || `${label} is a invalid time format`;
+    const message = getError(path) || `${label} is an invalid time format`;
     Schema = Schema.concat(Schema.matches(ISO_8601_TIME_REGEX, message));
   }
 
   if (format === "date") {
     const path = joinPath(description, "format.date");
-    const message = getError(path) || `${label} is a invalid date format`;
+    const message = getError(path) || `${label} is an invalid date format`;
     Schema = Schema.concat(Schema.matches(DATE_REGEX, message));
   }
 
@@ -123,7 +123,7 @@ export const stringSchemaFormat = (
 
   if (format === "email") {
     const path = joinPath(description, "format.email");
-    const message = getError(path) || `${label} is a invalid email format`;
+    const message = getError(path) || `${label} is an invalid email format`;
     Schema = Schema.concat(Schema.email(message));
   }
 
@@ -132,7 +132,7 @@ export const stringSchemaFormat = (
   if (format === "idn-email") {
     const path = joinPath(description, "format.idnEmail");
     const message =
-      getError(path) || `${label} is a invalid international email format`;
+      getError(path) || `${label} is an invalid international email format`;
     Schema = Schema.concat(Schema.matches(INTERNATIONAL_EMAIL_REGEX, message));
   }
 
@@ -140,14 +140,14 @@ export const stringSchemaFormat = (
 
   if (format === "hostname") {
     const path = joinPath(description, "format.hostname");
-    const message = getError(path) || `${label} is a invalid hostname format`;
+    const message = getError(path) || `${label} is an invalid hostname format`;
     Schema = Schema.concat(Schema.matches(HOSTNAME_REGEX, message));
   }
 
   if (format === "idn-hostname") {
     const path = joinPath(description, "format.idnHostname");
     const message =
-      getError(path) || `${label} is a invalid international hostname format`;
+      getError(path) || `${label} is an invalid international hostname format`;
     Schema = Schema.concat(
       Schema.matches(INTERNATIONAL_HOSTNAME_REGEX, message)
     );
@@ -157,13 +157,13 @@ export const stringSchemaFormat = (
 
   if (format === "ipv4") {
     const path = joinPath(description, "format.ipv4");
-    const message = getError(path) || `${label} is a invalid ipv4 format`;
+    const message = getError(path) || `${label} is an invalid ipv4 format`;
     Schema = Schema.concat(Schema.matches(IPV4_REGEX, message));
   }
 
   if (format === "ipv6") {
     const path = joinPath(description, "format.ipv6");
-    const message = getError(path) || `${label} is a invalid ipv6 format`;
+    const message = getError(path) || `${label} is an invalid ipv6 format`;
     Schema = Schema.concat(Schema.matches(IPV6_REGEX, message));
   }
 
@@ -171,14 +171,14 @@ export const stringSchemaFormat = (
 
   if (format === "uri") {
     const path = joinPath(description, "format.uri");
-    const message = getError(path) || `${label} is a invalid URI format`;
+    const message = getError(path) || `${label} is an invalid URI format`;
     Schema = Schema.concat(Schema.url(message));
   }
 
   if (format === "uri-reference") {
     const path = joinPath(description, "format.uriReference");
     const message =
-      getError(path) || `${label} is a invalid URI reference format`;
+      getError(path) || `${label} is an invalid URI reference format`;
 
     // `urlReference` is a custom yup method. See /yup/addons/index.ts
     // for implementation

--- a/src/yup/schemas/string/string.schema.ts
+++ b/src/yup/schemas/string/string.schema.ts
@@ -76,13 +76,13 @@ const createStringSchema = (
 
   if (isRegex(pattern)) {
     const path = joinPath(description, "pattern");
-    const message = getError(path) || `${label} is a incorrect format`;
+    const message = getError(path) || `${label} is an incorrect format`;
     Schema = Schema.concat(Schema.matches(pattern, message));
   }
 
   if (isRegex(regex)) {
     const path = joinPath(description, "regex");
-    const message = getError(path) || `${label} is a incorrect format`;
+    const message = getError(path) || `${label} is an incorrect format`;
     Schema = Schema.concat(Schema.matches(regex, message));
   }
 

--- a/src/yup/schemas/string/string.schema.ts
+++ b/src/yup/schemas/string/string.schema.ts
@@ -34,11 +34,14 @@ const createStringSchema = (
     maxLength,
     pattern,
     format,
-    regex
+    regex,
+    title
   } = value;
 
+  const label = title || capitalize(key);
+
   const defaultMessage =
-    getError("defaults.string") || capitalize(`${key} is not of type string`);
+    getError("defaults.string") || `${label} is not of type string`;
 
   let Schema = Yup.string().typeError(defaultMessage);
 
@@ -59,7 +62,7 @@ const createStringSchema = (
     const path = joinPath(description, "minLength");
     const message =
       getError(path) ||
-      capitalize(`${key} requires a minimum of ${minLength} characters`);
+      `${label} requires a minimum of ${minLength} characters`;
     Schema = Schema.concat(Schema.min(minLength, message));
   }
 
@@ -67,21 +70,19 @@ const createStringSchema = (
     const path = joinPath(description, "maxLength");
     const message =
       getError(path) ||
-      capitalize(`${key} cannot exceed a maximum of ${maxLength} characters`);
+      `${label} cannot exceed a maximum of ${maxLength} characters`;
     Schema = Schema.concat(Schema.max(maxLength, message));
   }
 
   if (isRegex(pattern)) {
     const path = joinPath(description, "pattern");
-    const message =
-      getError(path) || capitalize(`${key} is a incorrect format`);
+    const message = getError(path) || `${label} is a incorrect format`;
     Schema = Schema.concat(Schema.matches(pattern, message));
   }
 
   if (isRegex(regex)) {
     const path = joinPath(description, "regex");
-    const message =
-      getError(path) || capitalize(`${key} is a incorrect format`);
+    const message = getError(path) || `${label} is a incorrect format`;
     Schema = Schema.concat(Schema.matches(regex, message));
   }
 
@@ -95,26 +96,26 @@ export const stringSchemaFormat = (
   [key, value]: [string, JSONSchema7Extended],
   Schema: Yup.StringSchema
 ) => {
-  const { format, description } = value;
+  const { format, description, title } = value;
+
+  const label = title || capitalize(key);
 
   if (format === "date-time") {
     const path = joinPath(description, "format.dateTime");
     const message =
-      getError(path) || capitalize(`${key} is a invalid date and time format`);
+      getError(path) || `${label} is a invalid date and time format`;
     Schema = Schema.concat(Schema.matches(ISO_8601_DATE_TIME_REGEX, message));
   }
 
   if (format === "time") {
     const path = joinPath(description, "format.time");
-    const message =
-      getError(path) || capitalize(`${key} is a invalid time format`);
+    const message = getError(path) || `${label} is a invalid time format`;
     Schema = Schema.concat(Schema.matches(ISO_8601_TIME_REGEX, message));
   }
 
   if (format === "date") {
     const path = joinPath(description, "format.date");
-    const message =
-      getError(path) || capitalize(`${key} is a invalid date format`);
+    const message = getError(path) || `${label} is a invalid date format`;
     Schema = Schema.concat(Schema.matches(DATE_REGEX, message));
   }
 
@@ -122,8 +123,7 @@ export const stringSchemaFormat = (
 
   if (format === "email") {
     const path = joinPath(description, "format.email");
-    const message =
-      getError(path) || capitalize(`${key} is a invalid email format`);
+    const message = getError(path) || `${label} is a invalid email format`;
     Schema = Schema.concat(Schema.email(message));
   }
 
@@ -132,8 +132,7 @@ export const stringSchemaFormat = (
   if (format === "idn-email") {
     const path = joinPath(description, "format.idnEmail");
     const message =
-      getError(path) ||
-      capitalize(`${key} is a invalid international email format`);
+      getError(path) || `${label} is a invalid international email format`;
     Schema = Schema.concat(Schema.matches(INTERNATIONAL_EMAIL_REGEX, message));
   }
 
@@ -141,16 +140,14 @@ export const stringSchemaFormat = (
 
   if (format === "hostname") {
     const path = joinPath(description, "format.hostname");
-    const message =
-      getError(path) || capitalize(`${key} is a invalid hostname format`);
+    const message = getError(path) || `${label} is a invalid hostname format`;
     Schema = Schema.concat(Schema.matches(HOSTNAME_REGEX, message));
   }
 
   if (format === "idn-hostname") {
     const path = joinPath(description, "format.idnHostname");
     const message =
-      getError(path) ||
-      capitalize(`${key} is a invalid international hostname format`);
+      getError(path) || `${label} is a invalid international hostname format`;
     Schema = Schema.concat(
       Schema.matches(INTERNATIONAL_HOSTNAME_REGEX, message)
     );
@@ -160,15 +157,13 @@ export const stringSchemaFormat = (
 
   if (format === "ipv4") {
     const path = joinPath(description, "format.ipv4");
-    const message =
-      getError(path) || capitalize(`${key} is a invalid ipv4 format`);
+    const message = getError(path) || `${label} is a invalid ipv4 format`;
     Schema = Schema.concat(Schema.matches(IPV4_REGEX, message));
   }
 
   if (format === "ipv6") {
     const path = joinPath(description, "format.ipv6");
-    const message =
-      getError(path) || capitalize(`${key} is a invalid ipv6 format`);
+    const message = getError(path) || `${label} is a invalid ipv6 format`;
     Schema = Schema.concat(Schema.matches(IPV6_REGEX, message));
   }
 
@@ -176,15 +171,14 @@ export const stringSchemaFormat = (
 
   if (format === "uri") {
     const path = joinPath(description, "format.uri");
-    const message =
-      getError(path) || capitalize(`${key} is a invalid URI format`);
+    const message = getError(path) || `${label} is a invalid URI format`;
     Schema = Schema.concat(Schema.url(message));
   }
 
   if (format === "uri-reference") {
     const path = joinPath(description, "format.uriReference");
     const message =
-      getError(path) || capitalize(`${key} is a invalid URI reference format`);
+      getError(path) || `${label} is a invalid URI reference format`;
 
     // `urlReference` is a custom yup method. See /yup/addons/index.ts
     // for implementation

--- a/test/yup/array.test.ts
+++ b/test/yup/array.test.ts
@@ -339,4 +339,29 @@ describe("convertToYup() array", () => {
     });
     expect(valid).toBeTruthy();
   });
+
+  it("should use title as label in error message", () => {
+    const fieldTitle = "Item Types";
+    const schema: JSONSchema7 = {
+      type: "object",
+      $schema: "http://json-schema.org/draft-07/schema#",
+      $id: "test",
+      title: "Test",
+      properties: {
+        item: {
+          type: "array",
+          title: fieldTitle
+        }
+      }
+    };
+
+    let yupschema = convertToYup(schema) as Yup.ObjectSchema;
+    let errorMessage;
+    try {
+      errorMessage = yupschema.validateSync({ item: "test" });
+    } catch (e) {
+      errorMessage = e.errors[0];
+    }
+    expect(errorMessage).toBe(`${fieldTitle} is not of type array`);
+  });
 });

--- a/test/yup/boolean.test.ts
+++ b/test/yup/boolean.test.ts
@@ -155,4 +155,29 @@ describe("convertToYup() boolean", () => {
     }
     expect(errorMessage).toBe("Isactive does not match constant");
   });
+
+  it("should use title as label in error message", () => {
+    const fieldTitle = "Is Active";
+    const schema: JSONSchema7 = {
+      type: "object",
+      $schema: "http://json-schema.org/draft-07/schema#",
+      $id: "test",
+      title: "Test",
+      properties: {
+        isActive: {
+          type: "boolean",
+          title: fieldTitle
+        }
+      }
+    };
+
+    let yupschema = convertToYup(schema) as Yup.ObjectSchema;
+    let errorMessage;
+    try {
+      errorMessage = yupschema.validateSync({ isActive: "test" });
+    } catch (e) {
+      errorMessage = e.errors[0];
+    }
+    expect(errorMessage).toBe(`${fieldTitle} is not of type boolean`);
+  });
 });

--- a/test/yup/integer.test.ts
+++ b/test/yup/integer.test.ts
@@ -32,4 +32,29 @@ describe("convertToYup() integer", () => {
     });
     expect(isValid).toBeFalsy();
   });
+
+  it("should use title as label in error message", () => {
+    const fieldTitle = "Phone Number";
+    const schema: JSONSchema7 = {
+      type: "object",
+      $schema: "http://json-schema.org/draft-07/schema#",
+      $id: "test",
+      title: "Test",
+      properties: {
+        phone: {
+          type: "integer",
+          title: fieldTitle
+        }
+      }
+    };
+
+    let yupschema = convertToYup(schema) as Yup.ObjectSchema;
+    let errorMessage;
+    try {
+      errorMessage = yupschema.validateSync({ phone: "phone" });
+    } catch (e) {
+      errorMessage = e.errors[0];
+    }
+    expect(errorMessage).toBe(`${fieldTitle} is not of type integer`);
+  });
 });

--- a/test/yup/number.test.ts
+++ b/test/yup/number.test.ts
@@ -467,4 +467,29 @@ describe("convertToYup() number", () => {
       .isValidSync({});
     expect(isValid).toBeTruthy();
   });
+
+  it("should use title as label in error message", () => {
+    const fieldTitle = "My Age";
+    const schema: JSONSchema7 = {
+      type: "object",
+      $schema: "http://json-schema.org/draft-07/schema#",
+      $id: "test",
+      title: "Test",
+      properties: {
+        age: {
+          type: "number",
+          title: fieldTitle
+        }
+      }
+    };
+
+    let yupschema = convertToYup(schema) as Yup.ObjectSchema;
+    let errorMessage;
+    try {
+      errorMessage = yupschema.validateSync({ age: "Forty" });
+    } catch (e) {
+      errorMessage = e.errors[0];
+    }
+    expect(errorMessage).toBe(`${fieldTitle} is not of type number`);
+  });
 });

--- a/test/yup/string.format.test.ts
+++ b/test/yup/string.format.test.ts
@@ -59,7 +59,7 @@ describe("convertToYup() string format", () => {
     } catch (e) {
       errorMessage = e.errors[0];
     }
-    expect(errorMessage).toBe("Event is a invalid date and time format");
+    expect(errorMessage).toBe("Event is an invalid date and time format");
   });
 
   it("should validate time format", () => {
@@ -104,7 +104,7 @@ describe("convertToYup() string format", () => {
     } catch (e) {
       errorMessage = e.errors[0];
     }
-    expect(errorMessage).toBe("Event is a invalid time format");
+    expect(errorMessage).toBe("Event is an invalid time format");
   });
 
   it("should validate date format", () => {
@@ -143,7 +143,7 @@ describe("convertToYup() string format", () => {
     } catch (e) {
       errorMessage = e.errors[0];
     }
-    expect(errorMessage).toBe("Event is a invalid date format");
+    expect(errorMessage).toBe("Event is an invalid date format");
   });
 
   it("should validate email format", () => {
@@ -198,7 +198,7 @@ describe("convertToYup() string format", () => {
     } catch (e) {
       errorMessage = e.errors[0];
     }
-    expect(errorMessage).toBe("Email is a invalid email format");
+    expect(errorMessage).toBe("Email is an invalid email format");
   });
 
   it("should validate IDN email format", () => {
@@ -263,7 +263,7 @@ describe("convertToYup() string format", () => {
     } catch (e) {
       errorMessage = e.errors[0];
     }
-    expect(errorMessage).toBe("Email is a invalid international email format");
+    expect(errorMessage).toBe("Email is an invalid international email format");
   });
 
   it("should validate hostname format", () => {
@@ -301,7 +301,7 @@ describe("convertToYup() string format", () => {
     } catch (e) {
       errorMessage = e.errors[0];
     }
-    expect(errorMessage).toBe("Website is a invalid hostname format");
+    expect(errorMessage).toBe("Website is an invalid hostname format");
   });
 
   it("should validate international hostname format", () => {
@@ -345,7 +345,7 @@ describe("convertToYup() string format", () => {
       errorMessage = e.errors[0];
     }
     expect(errorMessage).toBe(
-      "Website is a invalid international hostname format"
+      "Website is an invalid international hostname format"
     );
   });
 
@@ -394,7 +394,7 @@ describe("convertToYup() string format", () => {
     } catch (e) {
       errorMessage = e.errors[0];
     }
-    expect(errorMessage).toBe("Website is a invalid ipv4 format");
+    expect(errorMessage).toBe("Website is an invalid ipv4 format");
   });
 
   it("should validate ipv6 format", () => {
@@ -442,7 +442,7 @@ describe("convertToYup() string format", () => {
     } catch (e) {
       errorMessage = e.errors[0];
     }
-    expect(errorMessage).toBe("Website is a invalid ipv6 format");
+    expect(errorMessage).toBe("Website is an invalid ipv6 format");
   });
 
   it("should validate uri format", () => {
@@ -495,7 +495,7 @@ describe("convertToYup() string format", () => {
     } catch (e) {
       errorMessage = e.errors[0];
     }
-    expect(errorMessage).toBe("Website is a invalid uri format");
+    expect(errorMessage).toBe("Website is an invalid URI format");
   });
 
   it("should validate uri relative path format", () => {
@@ -534,7 +534,7 @@ describe("convertToYup() string format", () => {
     } catch (e) {
       errorMessage = e.errors[0];
     }
-    expect(errorMessage).toBe("Website is a invalid uri reference format");
+    expect(errorMessage).toBe("Website is an invalid URI reference format");
   });
 
   it("should render warning for iri use", () => {

--- a/test/yup/string.test.ts
+++ b/test/yup/string.test.ts
@@ -214,7 +214,7 @@ describe("convertToYup() string", () => {
     } catch (e) {
       errorMessage = e.errors[0];
     }
-    expect(errorMessage).toBe("Name is a incorrect format");
+    expect(errorMessage).toBe("Name is an incorrect format");
   });
 
   it("should validate constant", () => {
@@ -380,6 +380,6 @@ describe("convertToYup() string", () => {
     } catch (e) {
       errorMessage = e.errors[0];
     }
-    expect(errorMessage).toBe("Name is a incorrect format");
+    expect(errorMessage).toBe("Name is an incorrect format");
   });
 });

--- a/test/yup/string.test.ts
+++ b/test/yup/string.test.ts
@@ -382,4 +382,30 @@ describe("convertToYup() string", () => {
     }
     expect(errorMessage).toBe("Name is an incorrect format");
   });
+
+  it("should use title as label in error message", () => {
+    const fieldTitle = "First Name";
+    const schema: JSONSchema7Extended = {
+      type: "object",
+      $schema: "http://json-schema.org/draft-07/schema#",
+      $id: "test",
+      title: "Test",
+      properties: {
+        name: {
+          type: "string",
+          title: fieldTitle
+        }
+      },
+      required: ["name"]
+    };
+
+    let yupschema = convertToYup(schema) as Yup.ObjectSchema;
+    let errorMessage;
+    try {
+      errorMessage = yupschema.validateSync({ name: "" });
+    } catch (e) {
+      errorMessage = e.errors[0];
+    }
+    expect(errorMessage).toBe(`${fieldTitle} is required`);
+  });
 });


### PR DESCRIPTION
Fixes #19. This also capitalizes only the key (if `title` is not set). Not only is this slightly more efficient, it allows for `URI` to be capitalized in the error message. I also fixed the grammar in a few spots ("a incorrect" -> "an incorrect").

@ritchieanesco Let me know if you have any suggestions.