### PR TITLE
Allow both schema keywords & types to be defined under 'defaults' and path

### DIFF
--- a/src/yup/config/index.ts
+++ b/src/yup/config/index.ts
@@ -1,5 +1,6 @@
 import get from "lodash/get";
-import { ConfigErrors, Config, isConfigError } from "../types";
+import { ConfigErrors, Config, isConfigError, NodeTypes } from "../types";
+import { joinPath } from "../utils";
 
 let config: Config = {};
 
@@ -25,3 +26,12 @@ export const getError = (path: string | false): string | false => {
   const errors = getErrors();
   return isConfigError(errors) && get(errors, pathArray);
 };
+
+/** Returns 'custom' or 'default' error message */
+export const getErrorMessage = (description: string | false | undefined, type: NodeTypes) => {
+  const customErrorMessage = description
+    ? getError(joinPath(description, type))
+    : undefined;
+
+  return customErrorMessage || getError(joinPath("defaults", type));
+}

--- a/src/yup/schemas/array/array.schema.ts
+++ b/src/yup/schemas/array/array.schema.ts
@@ -3,13 +3,13 @@ import isNumber from "lodash/isNumber";
 import isString from "lodash/isString";
 import isArray from "lodash/isArray";
 import capitalize from "lodash/capitalize";
-import { isItemsArray } from "../../../schema";
+import { DataTypes, isItemsArray } from "../../../schema";
 import Yup from "../../addMethods";
 import { createRequiredSchema } from "../required";
 import { createConstantSchema } from "../constant";
 import { createEnumerableSchema } from "../enumerables";
 import { SchemaItem } from "../../types";
-import { getError } from "../../config/";
+import { getError, getErrorMessage } from "../../config/";
 import { joinPath } from "../../utils";
 
 /**
@@ -33,8 +33,8 @@ const createArraySchema = (
 
   const label = title || capitalize(key);
 
-  const defaultMessage =
-    getError("defaults.array") || `${label} is not of type array`;
+  const defaultMessage = getErrorMessage(description, DataTypes.ARRAY)
+    || `${label} is not of type array`;
 
   let Schema = Yup.array().typeError(defaultMessage);
 

--- a/src/yup/schemas/boolean/boolean.schema.ts
+++ b/src/yup/schemas/boolean/boolean.schema.ts
@@ -5,7 +5,8 @@ import Yup from "../../addMethods";
 import { createRequiredSchema } from "../required";
 import { createConstantSchema } from "../constant";
 import { SchemaItem } from "../../types";
-import { getError } from "../../config/";
+import { getErrorMessage } from "../../config/";
+import { DataTypes } from "../../../schema";
 
 /**
  * Initializes a yup boolean schema derived from a json boolean schema
@@ -15,12 +16,16 @@ const createBooleanSchema = (
   [key, value]: SchemaItem,
   jsonSchema: JSONSchema7
 ): Yup.BooleanSchema<boolean> => {
-  const { default: defaults, title } = value;
+  const {
+    description,
+    default: defaults,
+    title
+  } = value;
 
   const label = title || capitalize(key);
 
-  const defaultMessage =
-    getError("defaults.boolean") || `${label} is not of type boolean`;
+  const defaultMessage = getErrorMessage(description, DataTypes.BOOLEAN)
+    || `${label} is not of type boolean`;
 
   let Schema = Yup.boolean().typeError(defaultMessage);
 

--- a/src/yup/schemas/composition/index.ts
+++ b/src/yup/schemas/composition/index.ts
@@ -2,9 +2,8 @@ import { JSONSchema7 } from "json-schema";
 import { capitalize } from "lodash";
 import createValidationSchema from "..";
 import Yup from "../../addMethods";
-import { getError } from "../../config";
-import { joinPath } from "../../utils";
-import type { AnyOfSchema7, AllOfSchema7, OneOfSchema7, NotSchema7 } from "../../../schema/types"
+import { getErrorMessage } from "../../config";
+import { AnyOfSchema7, AllOfSchema7, OneOfSchema7, NotSchema7, CompositSchemaTypes } from "../../../schema/types"
 
 /**
  * To validate against anyOf, the given data must be valid against any (one or more) of the given subschemas.
@@ -13,13 +12,14 @@ export const createAnyOfSchema = (
   [key, value]: [string, AnyOfSchema7],
   jsonSchema: JSONSchema7
 ): Yup.MixedSchema<string> => {
-  const path = joinPath(value.description, "anyOf");
-  const message = getError(path) || capitalize(`${key} does not match alternatives`);
+  const errorMessage = getErrorMessage(value.description, CompositSchemaTypes.ANYOF)
+    || capitalize(`${key} does not match alternatives`);
+
   const schemas = value.anyOf.map((val, i) => createValidationSchema([`${key}[${i}]`, val as JSONSchema7], jsonSchema));
 
   return Yup.mixed().test(
     "one-of-schema",
-    message,
+    errorMessage,
     function (current) {
       return schemas.some(s => s.isValidSync(current, this.options))
     }
@@ -33,14 +33,14 @@ export const createAllOfSchema = (
   [key, value]: [string, AllOfSchema7],
   jsonSchema: JSONSchema7
 ): Yup.MixedSchema<string> => {
-  const path = joinPath(value.description, "allOf");
-  const message =
-    getError(path) || capitalize(`${key} does not match all alternatives`);
+  const errorMessage = getErrorMessage(value.description, CompositSchemaTypes.ALLOF)
+    || capitalize(`${key} does not match all alternatives`);
+
   const schemas = value.allOf.map((val, i) => createValidationSchema([`${key}[${i}]`, val as JSONSchema7], jsonSchema));
 
   return Yup.mixed().test(
     "all-of-schema",
-    message,
+    errorMessage,
     function (current) {
       return schemas.every(s => s.isValidSync(current, this.options))
     }
@@ -54,14 +54,14 @@ export const createOneOfSchema = (
   [key, value]: [string, OneOfSchema7],
   jsonSchema: JSONSchema7
 ): Yup.MixedSchema<string> => {
-  const path = joinPath(value.description, "oneOf");
-  const message =
-    getError(path) || capitalize(`${key} does not match one alternative`);
+  const errorMessage = getErrorMessage(value.description, CompositSchemaTypes.ONEOF)
+    || capitalize(`${key} does not match one alternative`);
+
   const schemas = value.oneOf.map((val, i) => createValidationSchema([`${key}[${i}]`, val as JSONSchema7], jsonSchema));
 
   return Yup.mixed().test(
     "one-of-schema",
-    message,
+    errorMessage,
     function (current) {
       return schemas.filter(s => s.isValidSync(current, this.options)).length === 1;
     }
@@ -75,14 +75,14 @@ export const createNotSchema = (
   [key, value]: [string, NotSchema7],
   jsonSchema: JSONSchema7
 ): Yup.MixedSchema<string> => {
-  const path = joinPath(value.description, "not");
-  const message =
-    getError(path) || capitalize(`${key} matches alternatives`);
+  const errorMessage = getErrorMessage(value.description, CompositSchemaTypes.NOT)
+    || capitalize(`${key} matches alternatives`);
+
   const schema = createValidationSchema([key, value.not as JSONSchema7], jsonSchema);
 
   return Yup.mixed().test(
     "not-schema",
-    message,
+    errorMessage,
     function (current) {
       return schema.isValidSync(current, this.options) === false;
     }

--- a/src/yup/schemas/constant.ts
+++ b/src/yup/schemas/constant.ts
@@ -1,8 +1,8 @@
 import capitalize from "lodash/capitalize";
 import Yup from "../addMethods";
 import { SchemaItem } from "../types";
-import { getError } from "../config";
-import { joinPath } from "../utils";
+import { getErrorMessage } from "../config";
+import { SchemaKeywords } from "../../schema";
 
 /**
  * Add constant yup method when schema constant is declared
@@ -15,9 +15,9 @@ export const createConstantSchema = <T extends Yup.Schema<any>>(
   const { const: consts, description } = value;
 
   if (consts || consts === null || consts === 0) {
-    const path = joinPath(description, "const");
-    const message =
-      getError(path) || capitalize(`${key} does not match constant`);
+    const message = getErrorMessage(description, SchemaKeywords.CONST)
+      || capitalize(`${key} does not match constant`);
+
     Schema = Schema.concat(Schema.constant(consts, message));
   }
 

--- a/src/yup/schemas/enumerables.ts
+++ b/src/yup/schemas/enumerables.ts
@@ -2,8 +2,8 @@ import isArray from "lodash/isArray";
 import capitalize from "lodash/capitalize";
 import Yup from "../addMethods";
 import { SchemaItem } from "../types";
-import { getError } from "../config";
-import { joinPath } from "../utils";
+import { getErrorMessage } from "../config";
+import { SchemaKeywords } from "../../schema";
 
 /**
  * Add enum yup method when schema enum is declared
@@ -15,10 +15,9 @@ export const createEnumerableSchema = <T extends Yup.Schema<any>>(
 ): T => {
   const { enum: enums, description } = value;
   if (isArray(enums)) {
-    const path = joinPath(description, "enum");
-    const message =
-      getError(path) ||
-      capitalize(`${key} does not match any of the enumerables`);
+    const message = getErrorMessage(description, SchemaKeywords.ENUM)
+      || capitalize(`${key} does not match any of the enumerables`);
+
     Schema = Schema.concat(Schema.enum(enums, message));
   }
 

--- a/src/yup/schemas/integer/integer.schema.ts
+++ b/src/yup/schemas/integer/integer.schema.ts
@@ -3,7 +3,8 @@ import capitalize from "lodash/capitalize";
 import Yup from "../../addMethods";
 import { createBaseNumberSchema } from "../number";
 import { SchemaItem } from "../../types";
-import { getError } from "../../config/";
+import { getErrorMessage } from "../../config/";
+import { DataTypes } from "../../../schema";
 
 /**
  * Initializes a yup integer schema derived from a json humber schema
@@ -13,12 +14,15 @@ const createIntegerSchema = (
   [key, value]: SchemaItem,
   jsonSchema: JSONSchema7
 ): Yup.NumberSchema<number> => {
-  const { title } = value;
+  const {
+    description,
+    title
+  } = value;
 
   const label = title || capitalize(key);
+  const defaultMessage = getErrorMessage(description, DataTypes.INTEGER)
+    || `${label} is not of type integer`;
 
-  const defaultMessage =
-    getError("defaults.integer") || `${label} is not of type integer`;
   return createBaseNumberSchema(
     Yup.number().typeError(defaultMessage).integer().strict(true),
     [key, value],

--- a/src/yup/schemas/number/number.schema.ts
+++ b/src/yup/schemas/number/number.schema.ts
@@ -6,8 +6,8 @@ import { createRequiredSchema } from "../required";
 import { createConstantSchema } from "../constant";
 import { createEnumerableSchema } from "../enumerables";
 import { SchemaItem } from "../../types";
-import { getError } from "../../config/";
-import { joinPath } from "../../utils";
+import { getErrorMessage } from "../../config/";
+import { DataTypes, SchemaKeywords } from "../../../schema";
 
 /**
  * Initializes a yup number schema derived from a json number schema
@@ -17,12 +17,15 @@ const createNumberSchema = (
   [key, value]: SchemaItem,
   jsonSchema: JSONSchema7
 ): Yup.NumberSchema<number> => {
-  const { title } = value;
+  const {
+    description,
+    title
+  } = value;
 
   const label = title || capitalize(key);
 
-  const defaultMessage =
-    getError("defaults.number") || `${label} is not of type number`;
+  const defaultMessage = getErrorMessage(description, DataTypes.NUMBER)
+  || `${label} is not of type number`;
 
   return createBaseNumberSchema(
     Yup.number().typeError(defaultMessage),
@@ -75,20 +78,16 @@ export const createBaseNumberSchema = (
 
   // Minimum value is inclusive
   if (isMinNumber) {
-    const path = joinPath(description, "minimum");
-    const message =
-      getError(path) ||
-      capitalize(`${label} requires a minimum value of ${minimum}`);
+    const message = getErrorMessage(description, SchemaKeywords.MINIMUM)
+      || capitalize(`${label} requires a minimum value of ${minimum}`);
+
     Schema = Schema.concat(Schema.min(minimum as number, message));
   }
 
   if (isExclusiveMinNumber) {
-    const path = joinPath(description, "exclusiveMinimum");
-    const message =
-      getError(path) ||
-      capitalize(
-        `${label} requires a exclusive minimum value of ${exclusiveMinimum}`
-      );
+    const message = getErrorMessage(description, SchemaKeywords.EXCLUSIVE_MINIMUM)
+      || capitalize(`${label} requires a exclusive minimum value of ${exclusiveMinimum}`);
+
     Schema = Schema.concat(
       Schema.min((exclusiveMinimum as number) + 1, message)
     );
@@ -96,33 +95,27 @@ export const createBaseNumberSchema = (
 
   // Maximum value is inclusive
   if (isMaxNumber) {
-    const path = joinPath(description, "maximum");
-    const message =
-      getError(path) ||
-      capitalize(`${label} cannot exceed a maximum value of ${maximum}`);
+    const message = getErrorMessage(description, SchemaKeywords.MAXIMUM)
+      || capitalize(`${label} cannot exceed a maximum value of ${maximum}`);
+
     Schema = Schema.concat(Schema.max(maximum as number, message));
   }
 
   if (isExclusiveMaxNumber) {
-    const path = joinPath(description, "exclusiveMaximum");
-    const message =
-      getError(path) ||
-      capitalize(
-        `${label} cannot exceed a exclusive maximum value of ${exclusiveMaximum}`
-      );
+    const message = getErrorMessage(description, SchemaKeywords.EXCLUSIVE_MAXIMUM)
+      || capitalize(`${label} cannot exceed a exclusive maximum value of ${exclusiveMaximum}`);
+
     Schema = Schema.concat(
       Schema.max((exclusiveMaximum as number) - 1, message)
     );
   }
 
   if (multipleOf) {
-    const path = joinPath(description, "multipleOf");
-    const message =
-      getError(path) ||
-      capitalize(`${label} requires a multiple of ${multipleOf}`);
+    const message = getErrorMessage(description, SchemaKeywords.MULTIPLE_OF)
+      || capitalize(`${label} requires a multiple of ${multipleOf}`);
+
     // `multipleOf` is a custom yup method. See /yup/addons/index.ts
     // for implementation
-
     Schema = Schema.concat(Schema.multipleOf(multipleOf, message));
   }
 

--- a/src/yup/schemas/object/object.schema.ts
+++ b/src/yup/schemas/object/object.schema.ts
@@ -3,7 +3,8 @@ import capitalize from "lodash/capitalize";
 import { SchemaItem } from "../../types";
 import Yup from "../../addMethods";
 import { createRequiredSchema } from "../required";
-import { getError } from "../../config/";
+import { getErrorMessage } from "../../config/";
+import { DataTypes } from "../../../schema";
 
 /**
  * Initializes a yup object schema derived from a json object schema
@@ -13,12 +14,15 @@ const createObjectSchema = (
   [key, value]: SchemaItem,
   jsonSchema: JSONSchema7
 ): Yup.ObjectSchema<object> => {
-  const { title } = value;
+  const {
+    description,
+    title
+  } = value;
 
   const label = title || capitalize(key);
 
-  const defaultMessage =
-    getError("defaults.object") || `${label} is not of type object`;
+  const defaultMessage = getErrorMessage(description, DataTypes.OBJECT)
+    || capitalize(`${label}  is not of type object`);
 
   let Schema = Yup.object().typeError(defaultMessage);
 

--- a/src/yup/schemas/required.ts
+++ b/src/yup/schemas/required.ts
@@ -1,10 +1,9 @@
 import { JSONSchema7 } from "json-schema";
 import capitalize from "lodash/capitalize";
-import { isRequiredField } from "../../schema";
+import { isRequiredField, SchemaKeywords } from "../../schema";
 import Yup from "../addMethods";
 import { SchemaItem } from "../types";
-import { getError } from "../config";
-import { joinPath } from "../utils";
+import { getErrorMessage } from "../config";
 
 /**
  * Add required schema should subschema is required
@@ -19,7 +18,8 @@ export const createRequiredSchema = <T extends Yup.Schema<any>>(
 
   const { description, title } = value;
   const label = title || capitalize(key);
-  const path = joinPath(description, "required");
-  const message = getError(path) || `${label} is required`;
+  const message = getErrorMessage(description, SchemaKeywords.REQUIRED)
+    || `${label} is required`;
+
   return Schema.concat(Schema.required(message));
 };

--- a/src/yup/schemas/string/string.schema.ts
+++ b/src/yup/schemas/string/string.schema.ts
@@ -12,11 +12,11 @@ import {
   IPV4_REGEX,
   IPV6_REGEX
 } from "./string.constants";
-import { isRegex, JSONSchema7Extended } from "../../../schema";
+import { DataTypes, isRegex, JSONSchema7Extended, SchemaKeywords } from "../../../schema";
 import { createRequiredSchema } from "../required";
 import { createConstantSchema } from "../constant";
 import { createEnumerableSchema } from "../enumerables";
-import { getError } from "../../config/";
+import { getErrorMessage } from "../../config/";
 import { joinPath } from "../../utils";
 
 /**
@@ -40,8 +40,8 @@ const createStringSchema = (
 
   const label = title || capitalize(key);
 
-  const defaultMessage =
-    getError("defaults.string") || `${label} is not of type string`;
+  const defaultMessage = getErrorMessage(description, DataTypes.STRING)
+    || capitalize(`${label} is not of type string`);
 
   let Schema = Yup.string().typeError(defaultMessage);
 
@@ -59,30 +59,30 @@ const createStringSchema = (
   Schema = createEnumerableSchema(Schema, [key, value]);
 
   if (isNumber(minLength)) {
-    const path = joinPath(description, "minLength");
-    const message =
-      getError(path) ||
-      `${label} requires a minimum of ${minLength} characters`;
+    const message = getErrorMessage(description, SchemaKeywords.MINIMUM_LENGTH)
+      || `${label} requires a minimum of ${minLength} characters`;
+
     Schema = Schema.concat(Schema.min(minLength, message));
   }
 
   if (isNumber(maxLength)) {
-    const path = joinPath(description, "maxLength");
-    const message =
-      getError(path) ||
-      `${label} cannot exceed a maximum of ${maxLength} characters`;
+    const message = getErrorMessage(description, SchemaKeywords.MAXIMUM_LENGTH)
+      || `${label} cannot exceed a maximum of ${maxLength} characters`;
+
     Schema = Schema.concat(Schema.max(maxLength, message));
   }
 
   if (isRegex(pattern)) {
-    const path = joinPath(description, "pattern");
-    const message = getError(path) || `${label} is an incorrect format`;
+    const message = getErrorMessage(description, SchemaKeywords.PATTERN)
+      || `${label} is an incorrect format`;
+
     Schema = Schema.concat(Schema.matches(pattern, message));
   }
 
   if (isRegex(regex)) {
-    const path = joinPath(description, "regex");
-    const message = getError(path) || `${label} is an incorrect format`;
+    const message = getErrorMessage(description, SchemaKeywords.REGEX)
+      || `${label} is an incorrect format`;
+
     Schema = Schema.concat(Schema.matches(regex, message));
   }
 
@@ -101,53 +101,57 @@ export const stringSchemaFormat = (
   const label = title || capitalize(key);
 
   if (format === "date-time") {
-    const path = joinPath(description, "format.dateTime");
-    const message =
-      getError(path) || `${label} is an invalid date and time format`;
+    const path = joinPath(description, "format");
+    const message = getErrorMessage(path, SchemaKeywords.DATE_TIME_FORMAT)
+      || `${label} is an invalid date and time format`;
     Schema = Schema.concat(Schema.matches(ISO_8601_DATE_TIME_REGEX, message));
   }
 
   if (format === "time") {
-    const path = joinPath(description, "format.time");
-    const message = getError(path) || `${label} is an invalid time format`;
+    const path = joinPath(description, "format");
+    const message = getErrorMessage(path, SchemaKeywords.TIME_FORMAT)
+      || `${label} is an invalid time format`;
     Schema = Schema.concat(Schema.matches(ISO_8601_TIME_REGEX, message));
   }
 
   if (format === "date") {
-    const path = joinPath(description, "format.date");
-    const message = getError(path) || `${label} is an invalid date format`;
+    const path = joinPath(description, "format");
+    const message = getErrorMessage(path, SchemaKeywords.DATE_FORMAT)
+      || `${label} is an invalid date format`;
     Schema = Schema.concat(Schema.matches(DATE_REGEX, message));
   }
 
   // email
 
   if (format === "email") {
-    const path = joinPath(description, "format.email");
-    const message = getError(path) || `${label} is an invalid email format`;
+    const path = joinPath(description, "format");
+    const message = getErrorMessage(path, SchemaKeywords.EMAIL_FORMAT)
+      || `${label} is an invalid email format`;
     Schema = Schema.concat(Schema.email(message));
   }
 
   // international email format
 
   if (format === "idn-email") {
-    const path = joinPath(description, "format.idnEmail");
-    const message =
-      getError(path) || `${label} is an invalid international email format`;
+    const path = joinPath(description, "format");
+    const message = getErrorMessage(path, SchemaKeywords.IDN_EMAIL_FORMAT)
+      || `${label} is an invalid international email format`;
     Schema = Schema.concat(Schema.matches(INTERNATIONAL_EMAIL_REGEX, message));
   }
 
   // hostnames
 
   if (format === "hostname") {
-    const path = joinPath(description, "format.hostname");
-    const message = getError(path) || `${label} is an invalid hostname format`;
+    const path = joinPath(description, "format");
+    const message = getErrorMessage(path, SchemaKeywords.HOSTNAME_FORMAT)
+      || `${label} is an invalid hostname format`;
     Schema = Schema.concat(Schema.matches(HOSTNAME_REGEX, message));
   }
 
   if (format === "idn-hostname") {
-    const path = joinPath(description, "format.idnHostname");
-    const message =
-      getError(path) || `${label} is an invalid international hostname format`;
+    const path = joinPath(description, "format");
+    const message = getErrorMessage(path, SchemaKeywords.IDN_HOSTNAME_FORMAT)
+      || `${label} is an invalid international hostname format`;
     Schema = Schema.concat(
       Schema.matches(INTERNATIONAL_HOSTNAME_REGEX, message)
     );
@@ -156,29 +160,32 @@ export const stringSchemaFormat = (
   // ip addresses
 
   if (format === "ipv4") {
-    const path = joinPath(description, "format.ipv4");
-    const message = getError(path) || `${label} is an invalid ipv4 format`;
+    const path = joinPath(description, "format");
+    const message = getErrorMessage(path, SchemaKeywords.IPV4_FORMAT)
+      || `${label} is an invalid ipv4 format`;
     Schema = Schema.concat(Schema.matches(IPV4_REGEX, message));
   }
 
   if (format === "ipv6") {
-    const path = joinPath(description, "format.ipv6");
-    const message = getError(path) || `${label} is an invalid ipv6 format`;
+    const path = joinPath(description, "format");
+    const message = getErrorMessage(path, SchemaKeywords.IPV6_FORMAT)
+      || `${label} is an invalid ipv6 format`;
     Schema = Schema.concat(Schema.matches(IPV6_REGEX, message));
   }
 
   // resource identifiers
 
   if (format === "uri") {
-    const path = joinPath(description, "format.uri");
-    const message = getError(path) || `${label} is an invalid URI format`;
+    const path = joinPath(description, "format");
+    const message = getErrorMessage(path, SchemaKeywords.URI_FORMAT)
+      || `${label} is an invalid URI format`;
     Schema = Schema.concat(Schema.url(message));
   }
 
   if (format === "uri-reference") {
-    const path = joinPath(description, "format.uriReference");
-    const message =
-      getError(path) || `${label} is an invalid URI reference format`;
+    const path = joinPath(description, "format");
+    const message = getErrorMessage(path, SchemaKeywords.URI_REFERENCE_FORMAT)
+      || `${label} is an invalid URI reference format`;
 
     // `urlReference` is a custom yup method. See /yup/addons/index.ts
     // for implementation

--- a/src/yup/types.ts
+++ b/src/yup/types.ts
@@ -1,6 +1,6 @@
 import { JSONSchema7 } from "json-schema";
 import isPlainObject from "lodash/isPlainObject";
-import { SchemaKeywords, DataTypes } from "../schema";
+import { SchemaKeywords, DataTypes, CompositSchemaTypes } from "../schema";
 
 export const isConfigError = (
   errors: undefined | ConfigErrors
@@ -10,7 +10,7 @@ export type SchemaItem = [string, JSONSchema7];
 
 /* Configuration type to handle error messaging */
 
-type NodeTypes = SchemaKeywords | DataTypes;
+export type NodeTypes = SchemaKeywords | CompositSchemaTypes | DataTypes;
 
 export type ConfigErrorTypes = {
   [key in NodeTypes]?: string;

--- a/test/yup/configErrors.array.test.ts
+++ b/test/yup/configErrors.array.test.ts
@@ -3,7 +3,7 @@ import { JSONSchema7 } from "json-schema";
 import convertToYup from "../../src";
 
 describe("convertToYup() array configuration errors", () => {
-  it("should show configuration error for incorrect data type", () => {
+  it("should show default configuration error for incorrect data type", () => {
     const schema: JSONSchema7 = {
       type: "object",
       $schema: "http://json-schema.org/draft-07/schema#",
@@ -32,7 +32,68 @@ describe("convertToYup() array configuration errors", () => {
     expect(errorMessage).toBe(config.errors.defaults.array);
   });
 
-  it("should show configuration error for required", () => {
+  it("should show custom configuration error for incorrect data type", () => {
+    const schema: JSONSchema7 = {
+      type: "object",
+      $schema: "http://json-schema.org/draft-07/schema#",
+      $id: "test",
+      title: "Test",
+      properties: {
+        groceries: {
+          type: "array"
+        }
+      }
+    };
+    const config = {
+      errors: {
+        groceries: {
+          array: "Default array message"
+        }
+      }
+    };
+    const yupschema = convertToYup(schema, config) as Yup.ObjectSchema;
+    let errorMessage;
+    try {
+      errorMessage = yupschema.validateSync({ groceries: "ABC" });
+    } catch (e) {
+      errorMessage = e.errors[0];
+    }
+    expect(errorMessage).toBe(config.errors.groceries.array);
+  });
+
+  it("should override defaults configuration error for incorrect data type", () => {
+    const schema: JSONSchema7 = {
+      type: "object",
+      $schema: "http://json-schema.org/draft-07/schema#",
+      $id: "test",
+      title: "Test",
+      properties: {
+        groceries: {
+          type: "array"
+        }
+      }
+    };
+    const config = {
+      errors: {
+        defaults: {
+          array: "Default array message"
+        },
+        groceries: {
+          array: "Custom array message"
+        }
+      }
+    };
+    const yupschema = convertToYup(schema, config) as Yup.ObjectSchema;
+    let errorMessage;
+    try {
+      errorMessage = yupschema.validateSync({ groceries: "ABC" });
+    } catch (e) {
+      errorMessage = e.errors[0];
+    }
+    expect(errorMessage).toBe(config.errors.groceries.array);
+  });
+
+  it("should show defaults configuration error for required", () => {
     const schema: JSONSchema7 = {
       type: "object",
       $schema: "http://json-schema.org/draft-07/schema#",
@@ -47,6 +108,69 @@ describe("convertToYup() array configuration errors", () => {
     };
     const config = {
       errors: {
+        defaults: {
+          required: "Field is required"
+        }
+      }
+    };
+    const yupschema = convertToYup(schema, config) as Yup.ObjectSchema;
+    let errorMessage;
+    try {
+      errorMessage = yupschema.validateSync({});
+    } catch (e) {
+      errorMessage = e.errors[0];
+    }
+    expect(errorMessage).toBe(config.errors.defaults.required);
+  });
+
+  it("should show custom configuration error for required", () => {
+    const schema: JSONSchema7 = {
+      type: "object",
+      $schema: "http://json-schema.org/draft-07/schema#",
+      $id: "test",
+      title: "Test",
+      properties: {
+        groceries: {
+          type: "array"
+        }
+      },
+      required: ["groceries"]
+    };
+    const config = {
+      errors: {
+        groceries: {
+          required: "Groceries (array) is required"
+        }
+      }
+    };
+    const yupschema = convertToYup(schema, config) as Yup.ObjectSchema;
+    let errorMessage;
+    try {
+      errorMessage = yupschema.validateSync({});
+    } catch (e) {
+      errorMessage = e.errors[0];
+    }
+    expect(errorMessage).toBe(config.errors.groceries.required);
+  });
+
+  it("should override defaults configuration error for required", () => {
+    const schema: JSONSchema7 = {
+      type: "object",
+      $schema: "http://json-schema.org/draft-07/schema#",
+      $id: "test",
+      title: "Test",
+      properties: {
+        groceries: {
+          type: "array"
+        }
+      },
+      required: ["groceries"]
+    };
+    const config = {
+      errors: {
+        defaults: {
+          required: "Field is required"
+        },
         groceries: {
           required: "Groceries (array) is required"
         }


### PR DESCRIPTION
This allows users to define a set of default error messages, and override specific messages using the path structure.

@ritchieanesco, i have not finished updating tests, as i wanted to validate the approach before spending a lot of time going through them.