### PR TITLE
Allow multiple conditionals in a schema object

### DIFF
--- a/src/yup/builder/index.ts
+++ b/src/yup/builder/index.ts
@@ -66,11 +66,25 @@ const buildProperties = (
       const condition = hasIfSchema(jsonSchema, key)
         ? buildCondition(jsonSchema)
         : {};
+      // check if item has if schema in allOf array
+      const conditions = hasAllOfIfSchema(jsonSchema, key)
+        ? jsonSchema.allOf?.reduce((all, schema) => {
+            if (typeof schema === "boolean") {
+              return all;
+            }
+            all = {
+              ...all,
+              ...buildCondition(schema)
+            };
+            return all;
+          }, [])
+        : [];       
       const newSchema = createValidationSchema([key, value], jsonSchema);
       schema = {
         ...schema,
         [key]: key in schema ? schema[key].concat(newSchema) : newSchema,
-        ...condition
+        ...condition,
+        ...conditions
       };
     }
   }
@@ -86,6 +100,22 @@ const hasIfSchema = (jsonSchema: JSONSchema7, key: string): boolean => {
   if (!isSchemaObject(ifSchema)) return false;
   const { properties } = ifSchema;
   return isPlainObject(properties) && has(properties, key);
+};
+
+/**
+ * Determine schema has at least one if schemas inside an allOf array
+ */
+
+const hasAllOfIfSchema = (jsonSchema: JSONSchema7, key: string): boolean => {
+  const { allOf } = jsonSchema;
+
+  if (!allOf) {
+    return false;
+  }
+
+  return allOf.some(
+    (schema) => typeof schema !== "boolean" && hasIfSchema(schema, key)
+  );
 };
 
 /**

--- a/src/yup/builder/index.ts
+++ b/src/yup/builder/index.ts
@@ -72,11 +72,7 @@ const buildProperties = (
             if (typeof schema === "boolean") {
               return all;
             }
-            all = {
-              ...all,
-              ...buildCondition(schema)
-            };
-            return all;
+            return { ...all, ...buildCondition(schema) };
           }, [])
         : [];       
       const newSchema = createValidationSchema([key, value], jsonSchema);

--- a/src/yup/schemas/composition/index.ts
+++ b/src/yup/schemas/composition/index.ts
@@ -36,7 +36,11 @@ export const createAllOfSchema = (
   const path = joinPath(value.description, "allOf");
   const message =
     getError(path) || capitalize(`${key} does not match all alternatives`);
-  const schemas = value.allOf.map((val, i) => createValidationSchema([`${key}[${i}]`, val as JSONSchema7], jsonSchema));
+  const schemas = value.allOf
+    .filter((el) => typeof el !== "boolean" && el.type)
+    .map((val, i) =>
+      createValidationSchema([`${key}[${i}]`, val as JSONSchema7], jsonSchema)
+    );
 
   return Yup.mixed().test(
     "all-of-schema",

--- a/test/yup/allOf.if.test.ts
+++ b/test/yup/allOf.if.test.ts
@@ -1,0 +1,229 @@
+import * as Yup from "yup";
+import { JSONSchema7 } from "json-schema";
+import convertToYup from "../../src";
+
+// Note: Unit tests cover the core functionality. Formats have been excluded
+// as all those validators use the pattern method
+
+describe("convertToYup() string conditions", () => {
+  it("should validate single if statement in allOf", () => {
+    const schema: JSONSchema7 = {
+      type: "object",
+      $schema: "http://json-schema.org/draft-07/schema#",
+      $id: "test",
+      title: "Test",
+      properties: {
+        country: {
+          type: "string",
+          enum: ["Australia", "Canada"]
+        }
+      },
+      required: ["country"],
+      allOf: [
+        {
+          if: {
+            properties: { country: { type: "string", const: "Australia" } }
+          },
+          then: {
+            properties: {
+              postal_code: { type: "string", pattern: "[0-9]{5}(-[0-9]{4})?" }
+            },
+            required: ["postal_code"]
+          }
+        }
+      ]
+    };
+    const yupschema = convertToYup(schema) as Yup.ObjectSchema;
+
+    let isValid = yupschema.isValidSync({
+      country: "Australia"
+    });
+    expect(isValid).toBeFalsy();
+  });
+  it("should ignore non-relevant if statements in allOf", () => {
+    const schema: JSONSchema7 = {
+      type: "object",
+      $schema: "http://json-schema.org/draft-07/schema#",
+      $id: "test",
+      title: "Test",
+      properties: {
+        country: {
+          type: "string",
+          enum: ["Australia", "Canada"]
+        }
+      },
+      required: ["country"],
+      allOf: [
+        {
+          if: {
+            properties: { country: { type: "string", const: "Canada" } }
+          },
+          then: {
+            properties: {
+              postal_code: { type: "string", pattern: "[0-9]{5}(-[0-9]{4})?" }
+            },
+            required: ["postal_code"]
+          }
+        }
+      ]
+    };
+    const yupschema = convertToYup(schema) as Yup.ObjectSchema;
+
+    let isValid = yupschema.isValidSync({
+      country: "Australia"
+    });
+    expect(isValid).toBeTruthy();
+  });
+  it("should validate multiple if statement in allOf", () => {
+    const schema: JSONSchema7 = {
+      type: "object",
+      $schema: "http://json-schema.org/draft-07/schema#",
+      $id: "test",
+      title: "Test",
+      properties: {
+        country: {
+          type: "string",
+          enum: ["Australia", "Canada"]
+        },
+        isMinor: {
+          type: "boolean"
+        }
+      },
+      required: ["country", "isMinor"],
+      allOf: [
+        {
+          if: {
+            properties: { isMinor: { type: "boolean", const: true } }
+          },
+          then: {
+            properties: { hasParentConsent: { type: "boolean" } },
+            required: ["hasParentConsent"]
+          }
+        },
+        {
+          if: {
+            properties: { country: { type: "string", const: "Australia" } }
+          },
+          then: {
+            properties: {
+              postal_code: { type: "string", pattern: "[0-9]{5}(-[0-9]{4})?" }
+            },
+            required: ["postal_code"]
+          }
+        }
+      ]
+    };
+    const yupschema = convertToYup(schema) as Yup.ObjectSchema;
+
+    const notValid1 = yupschema.isValidSync({
+      country: "Canada",
+      isMinor: true
+    });
+    expect(notValid1).toBeFalsy();
+
+    const notValid2 = yupschema.isValidSync({
+      country: "Australia",
+      isMinor: false
+    });
+    expect(notValid2).toBeFalsy();
+
+    const notValid3 = yupschema.isValidSync({
+      country: "Australia",
+      isMinor: true
+    });
+    expect(notValid3).toBeFalsy();
+
+    const notValid4 = yupschema.isValidSync({
+      country: "Australia",
+      isMinor: true,
+      postal_code: "12345"
+    });
+    expect(notValid4).toBeFalsy();
+
+    const notValid5 = yupschema.isValidSync({
+      country: "Australia",
+      isMinor: true,
+      hasParentConsent: true
+    });
+    expect(notValid5).toBeFalsy();
+
+    const isValid1 = yupschema.isValidSync({
+      country: "Australia",
+      isMinor: false,
+      postal_code: "12345"
+    });
+    expect(isValid1).toBeTruthy();
+
+    const isValid2 = yupschema.isValidSync({
+      country: "Australia",
+      isMinor: true,
+      postal_code: "12345",
+      hasParentConsent: true
+    });
+    expect(isValid2).toBeTruthy();
+  });
+  it("should validate deep schema", () => {
+    const schema: JSONSchema7 = {
+      type: "object",
+      $schema: "http://json-schema.org/draft-07/schema#",
+      $id: "test",
+      title: "Test",
+      definitions: {
+        location: {
+          $id: "/definitions/location",
+          $schema: "https://json-schema.org/draft/2020-12/schema",
+          type: "object",
+          properties: {
+            country: {
+              type: "string",
+              enum: ["Australia", "Canada"]
+            }
+          },
+          required: ["country"],
+          allOf: [
+            {
+              if: {
+                properties: { country: { type: "string", const: "Australia" } }
+              },
+              then: {
+                properties: {
+                  postal_code: {
+                    type: "string",
+                    pattern: "[0-9]{5}(-[0-9]{4})?"
+                  }
+                },
+                required: ["postal_code"]
+              }
+            }
+          ]
+        }
+      },
+      properties: {
+        location: {
+          description: "",
+          $ref: "#/definitions/location"
+        }
+      },
+      required: ["location"]
+    };
+
+    const yupschema = convertToYup(schema) as Yup.ObjectSchema;
+
+    const isValid = yupschema.isValidSync({
+      location: {
+        country: "Australia",
+        isMinor: true,
+        postal_code: "12345",
+        hasParentConsent: true
+      }
+    });
+    expect(isValid).toBeTruthy();
+
+    const isInvalid = yupschema.isValidSync({
+      location: {
+        country: "Australia"
+      }
+    });
+    expect(isInvalid).toBeFalsy();
+  });
+});


### PR DESCRIPTION
# Proposed change

Adds the ability to have multiple conditional rules as requested in #12 using the `allOf` key per the JSON Schema specification.

- [x] All existing tests passing
- [x] A bunch of new tests for multiple conditional scenarios 

# Notes

This PR largely uses existing helpers, iterating over/flattening rules inside of the `allOf` array.