### PR TITLE
Improve checks for exclusiveMinimum and exclusiveMaximum.

### DIFF
--- a/src/yup/schemas/number/number.schema.ts
+++ b/src/yup/schemas/number/number.schema.ts
@@ -96,7 +96,7 @@ export const createBaseNumberSchema = (
       );
 
     Schema = Schema.concat(
-      Schema.min((exclusiveMinimum as number) + 1, message)
+      Schema.moreThan((exclusiveMinimum as number), message)
     );
   }
 
@@ -122,7 +122,7 @@ export const createBaseNumberSchema = (
       );
 
     Schema = Schema.concat(
-      Schema.max((exclusiveMaximum as number) - 1, message)
+      Schema.lessThan((exclusiveMaximum as number), message)
     );
   }
 


### PR DESCRIPTION
The current implementation of `exclusiveMinimum` and `exclusiveMaximum` incorrectly assumes integer values. Improved to consider real numbers.

Please note that the test suite still passes. However, it was tested against `v1.6.4` because the test suite currently fails on master (see https://github.com/ritchieanesco/json-schema-yup-transform/issues/60).

![image](https://user-images.githubusercontent.com/9569236/172224712-fdd9e43c-6fb0-4744-bd91-9f85a23f1f2d.png)
